### PR TITLE
fix: re-enable artifacts for PRs again

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -111,7 +111,7 @@ jobs:
           echo "output_directory=$OUTPUT_DIRECTORY" >> "${GITHUB_OUTPUT}"
 
       - name: Upload to Job Artifacts
-        if: inputs.upload_artifacts
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ steps.image_ref.outputs.artifact_format }}


### PR DESCRIPTION
This would only run when it uploads to our testing bucket, which would make it redundant. So we can have testing before it makes it to the testing bucket.