### PR TITLE
chore: disable bazaar service

### DIFF
--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -23,6 +23,7 @@ systemctl disable ublue-system-setup.service
 systemctl disable flatpak-preinstall.service
 systemctl --global disable podman-auto-update.timer
 systemctl --global disable ublue-user-setup.service
+systemctl --global disable bazaar.service
 rm /usr/share/applications/system-update.desktop
 
 # HACK for https://bugzilla.redhat.com/show_bug.cgi?id=2433186


### PR DESCRIPTION
This consumes unnecessary resources, search results aren't really needed in the live environment.