### PR TITLE
feat: produce BETA isos

### DIFF
--- a/.github/workflows/build-iso-beta.yml
+++ b/.github/workflows/build-iso-beta.yml
@@ -1,0 +1,34 @@
+---
+name: Build Beta ISOs
+on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/build-iso-beta.yml"
+      - ".github/workflows/reusable-build-iso-anaconda.yml"
+      - "iso_files/**"
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      upload_artifacts:
+        description: 'Upload ISOs as job artifacts'
+        type: boolean
+        default: false
+      upload_r2:
+        description: 'Upload ISOs to Cloudflare R2'
+        type: boolean
+        default: true
+
+jobs:
+  build-iso-beta:
+    name: Build Beta ISOs
+    uses: ./.github/workflows/reusable-build-iso-anaconda.yml
+    secrets: inherit
+    with:
+      image_version: beta
+      # Upload artifacts on PR checks or if manually requested
+      upload_artifacts: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.upload_artifacts) }}
+      # Upload to R2 on merge_group or if manually requested
+      upload_r2: ${{ github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.upload_r2) }}

--- a/.github/workflows/promote-iso.yml
+++ b/.github/workflows/promote-iso.yml
@@ -39,7 +39,10 @@ jobs:
       - name: List files in Test bucket
         run: |
           echo "Files in Test bucket:"
-          /home/linuxbrew/.linuxbrew/bin/rclone ls R2_TEST:aurora-dl-test --include "*.iso" --include "*.iso-CHECKSUM"
+          /home/linuxbrew/.linuxbrew/bin/rclone ls R2_TEST:aurora-dl-test \
+            --include "*.iso" \
+            --include "*.iso-CHECKSUM" \
+            --exclude "aurora-beta-*"
 
       - name: Promote ISOs (Dry Run)
         if: inputs.dry_run == true
@@ -48,6 +51,7 @@ jobs:
           /home/linuxbrew/.linuxbrew/bin/rclone sync R2_TEST:aurora-dl-test R2_PROD:aurora-dl \
             --include "*.iso" \
             --include "*.iso-CHECKSUM" \
+            --exclude "aurora-beta-*" \
             --dry-run \
             --verbose
 
@@ -58,6 +62,7 @@ jobs:
           /home/linuxbrew/.linuxbrew/bin/rclone sync R2_TEST:aurora-dl-test R2_PROD:aurora-dl \
             --include "*.iso" \
             --include "*.iso-CHECKSUM" \
+            --exclude "aurora-beta-*" \
             --verbose \
             --progress
 

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -11,6 +11,14 @@ on:
         description: 'Upload ISOs to Cloudflare R2'
         type: boolean
         default: true
+      image_version:
+        description: 'Image version/tag to build (e.g. stable, beta)'
+        type: string
+        default: stable
+      hook_script:
+        description: 'Path to the ISO post-rootfs hook script'
+        type: string
+        default: iso_files/configure_iso_anaconda.sh
 
 env:
   IMAGE_REGISTRY: "ghcr.io/ublue-os"
@@ -29,7 +37,7 @@ jobs:
       matrix:
         platform: [amd64]
         flavor: ["main", "nvidia-open"]
-        image_version: ["stable"]
+        image_version: ["${{ inputs.image_version }}"]
     permissions:
       contents: read
       packages: read
@@ -83,7 +91,7 @@ jobs:
         with:
           image-ref: ${{ steps.image_ref.outputs.image_ref }}:${{ matrix.image_version }}
           flatpaks-list: ${{ steps.flatpak_list.outputs.file_list_path }}
-          hook-post-rootfs: ${{ github.workspace }}/iso_files/configure_iso_anaconda.sh
+          hook-post-rootfs: ${{ github.workspace }}/${{ inputs.hook_script }}
           kargs: ${{ steps.image_ref.outputs.kargs }}
 
       - name: Rename ISO

--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,7 @@ flavors := '(
 tags := '(
     [stable]=stable
     [latest]=latest
+    [beta]=beta
 )'
 export SUDO_DISPLAY := if `if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then echo true; fi` == "true" { "true" } else { "false" }
 export SUDOIF := if `id -u` == "0" { "" } else if SUDO_DISPLAY == "true" { "sudo --askpass" } else { "sudo" }

--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -27,15 +27,17 @@ rm /usr/share/applications/dev.getaurora.system-update.desktop
 
 systemctl --global disable bazaar.service
 
-# HACK for https://bugzilla.redhat.com/show_bug.cgi?id=2433186
-rpm --erase --nodeps --justdb generic-logos
-dnf download fedora-logos
-rpm -i --justdb fedora-logos*.rpm
-rm -f fedora-logos*.rpm
+#TODO: Remove once F44 is on stable
+if [[ "${IMAGE_TAG}" == "stable" ]]; then
+    # HACK for https://bugzilla.redhat.com/show_bug.cgi?id=2433186
+    rpm --erase --nodeps --justdb generic-logos
+    dnf download fedora-logos
+    rpm -i --justdb fedora-logos*.rpm
+    rm -f fedora-logos*.rpm
+fi
 
 # Configure Anaconda
 
-# Install Anaconda WebUI
 SPECS=(
     "libblockdev-btrfs"
     "libblockdev-lvm"
@@ -46,13 +48,16 @@ SPECS=(
 
 dnf install -y "${SPECS[@]}"
 
-rpm --erase --nodeps --justdb fedora-logos
+#TODO: Remove once F44 is on stable
+if [[ "${IMAGE_TAG}" == "stable" ]]; then
+    rpm --erase --nodeps --justdb fedora-logos
+fi
 
 # Anaconda Profile Detection
 
 # Aurora
 tee /etc/anaconda/profile.d/aurora.conf <<'EOF'
-# Anaconda configuration file for Aurora Stable
+# Anaconda configuration file for Aurora
 
 [Profile]
 # Define the profile.
@@ -86,6 +91,11 @@ hidden_webui_pages =
     root-password
     network
 EOF
+
+if [[ "${IMAGE_TAG}" == "beta" ]]; then
+    sed -i '/hidden_spokes =/a \    UserSpoke' /etc/anaconda/profile.d/aurora.conf
+    sed -i '/hidden_webui_pages =/a \    anaconda-screen-accounts' /etc/anaconda/profile.d/aurora.conf
+fi
 
 # add intaller to kickoff
 sed -i '2s/$/;liveinst.desktop/' /usr/share/kde-settings/kde-profile/default/xdg/kicker-extra-favoritesrc


### PR DESCRIPTION
Builds BETA ISOs based on `aurora:beta`

- AMD version builds fine and seems to work (tested on a VM)
- Nvidia builds on 43 as there is no working 44 beta image in ublue-os/aurora (for now atleast)

Modified the ISO promotion workflow to always exclude beta images being synced to PROD bucket

Closes https://github.com/ublue-os/aurora/issues/1719