### PR TITLE
chore: rename beta to testing

### DIFF
--- a/.github/workflows/build-iso-testing.yml
+++ b/.github/workflows/build-iso-testing.yml
@@ -1,12 +1,12 @@
 ---
-name: Build Beta ISOs
+name: Build Testing ISOs
 on:
   merge_group:
   pull_request:
     branches:
       - main
     paths:
-      - ".github/workflows/build-iso-beta.yml"
+      - ".github/workflows/build-iso-testing.yml"
       - ".github/workflows/reusable-build-iso-anaconda.yml"
       - "iso_files/**"
   workflow_call:
@@ -24,12 +24,12 @@ on:
     - cron: "0 3 * * 3" # Push to testing bucket every week at 03:00 on Wednesdays
 
 jobs:
-  build-iso-beta:
-    name: Build Beta ISOs
+  build-iso-testing:
+    name: Build Testing ISOs
     uses: ./.github/workflows/reusable-build-iso-anaconda.yml
     secrets: inherit
     with:
-      image_version: beta
+      image_version: testing
       # Upload artifacts on PR checks or if manually requested
       upload_artifacts: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.upload_artifacts) }}
       # Upload to R2 on merge_group or if manually requested

--- a/.github/workflows/promote-iso.yml
+++ b/.github/workflows/promote-iso.yml
@@ -38,19 +38,19 @@ jobs:
 
       - name: List files in Test bucket
         run: |
-          echo "Files in Test bucket (including beta - beta ISOs will NOT be promoted):"
+          echo "Files in Test bucket (including testing - testing ISOs will NOT be promoted):"
           /home/linuxbrew/.linuxbrew/bin/rclone ls R2_TEST:aurora-dl-test \
             --filter "+ *.iso" \
             --filter "+ *.iso-CHECKSUM" \
             --filter "- *"
-          echo "::notice::Beta ISOs (*-beta-*) are listed above but will be excluded from promotion."
+          echo "::notice::Testing ISOs (*-testing-*) are listed above but will be excluded from promotion."
 
       - name: Promote ISOs (Dry Run)
         if: inputs.dry_run == true
         run: |
           echo "Running in DRY RUN mode - no files will be copied"
           /home/linuxbrew/.linuxbrew/bin/rclone sync R2_TEST:aurora-dl-test R2_PROD:aurora-dl \
-            --filter "- *-beta-*" \
+            --filter "- *-testing-*" \
             --filter "+ *.iso" \
             --filter "+ *.iso-CHECKSUM" \
             --filter "- *" \
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo "Promoting ISOs from Test to Production"
           /home/linuxbrew/.linuxbrew/bin/rclone sync R2_TEST:aurora-dl-test R2_PROD:aurora-dl \
-            --filter "- *-beta-*" \
+            --filter "- *-testing-*" \
             --filter "+ *.iso" \
             --filter "+ *.iso-CHECKSUM" \
             --filter "- *" \

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         default: true
       image_version:
-        description: 'Image version/tag to build (e.g. stable, beta)'
+        description: 'Image version/tag to build (e.g. stable, testing)'
         type: string
         default: stable
       hook_script:

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ flavors := '(
 tags := '(
     [stable]=stable
     [latest]=latest
-    [beta]=beta
+    [testing]=testing
 )'
 export SUDO_DISPLAY := if `if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then echo true; fi` == "true" { "true" } else { "false" }
 export SUDOIF := if `id -u` == "0" { "" } else if SUDO_DISPLAY == "true" { "sudo --askpass" } else { "sudo" }


### PR DESCRIPTION
We are always building :testing now, there will not be a dedicated :beta tag.

xref https://github.com/ublue-os/aurora/issues/1647